### PR TITLE
Fixed issue with extra ampersand being included right after question mark.

### DIFF
--- a/src/adapter-ajax-httpclient.ts
+++ b/src/adapter-ajax-httpclient.ts
@@ -1,6 +1,7 @@
 ﻿import { HttpClient, HttpErrorResponse, HttpEvent, HttpHeaders, HttpRequest, HttpResponse } from "@angular/common/http";
 import { AjaxConfig, config, core, HttpResponse as BreezeHttpResponse, BreezeConfig } from "breeze-client";
 import { filter, map } from "rxjs/operators";
+import { appendQueryStringParameters } from "./adapter-core";
 
 export class AjaxHttpClientAdapter {
   static adapterName = 'httpclient';
@@ -36,13 +37,9 @@ export class AjaxHttpClientAdapter {
       throw new Error(this.name + ' does not support JSONP (crossDomain) requests');
     }
 
-    let url = config.url;
-    if (!core.isEmpty(config.params)) {
-      // Hack: Not sure how Angular handles writing 'search' parameters to the url.
-      // so this approach takes over the url param writing completely.
-      let delim = (url.indexOf('?') >= 0) ? '&' : '?';
-      url = url + delim + encodeParams(config.params);
-    }
+    let parameters = core.isEmpty(config.params) ? null : encodeParams(config.params);
+
+    const url = appendQueryStringParameters(parameters, config.url);
 
     let headers = new HttpHeaders(config.headers || {});
     if (!headers.has('Content-Type')) {

--- a/src/adapter-core.ts
+++ b/src/adapter-core.ts
@@ -1,0 +1,17 @@
+export function appendQueryStringParameters(parameters: string, url: string){
+    if(!parameters) return url;
+
+    let separator: string;
+
+    if(url.endsWith("?")){
+        separator = "";
+    }
+    else if(url.includes("?")){
+        separator = "&";
+    }
+    else{
+        separator = "?";
+    }
+
+    return url + separator + parameters;
+}

--- a/src/adapter-uri-builder-odata.ts
+++ b/src/adapter-uri-builder-odata.ts
@@ -1,4 +1,5 @@
 ﻿import * as breeze from 'breeze-client';
+import { appendQueryStringParameters } from "./adapter-core";
 
 export class UriBuilderODataAdapter implements breeze.UriBuilderAdapter {
 
@@ -44,8 +45,8 @@ export class UriBuilderODataAdapter implements breeze.UriBuilderAdapter {
     }
 
     let qoText = toQueryOptionsString(queryOptions as breeze.QueryOptions);
-    let sep = entityQuery.resourceName.includes("?") ? "&" : "?";
-    return entityQuery.resourceName + sep + qoText;
+
+    return appendQueryStringParameters(qoText, entityQuery.resourceName);
 
     // private methods to this func.
 


### PR DESCRIPTION
An extra ampersand was being included after the question mark when appending query string parameters.

https://www.example.com?&parameter1=value1

This caused problems with requests to controller methods on the server that included optional parameters. The request did not get routed to the correct controller method and resulted in a 404.

Note that supplying values for the optional parameters was a workaround.

I extracted the logic from the two adapters that I was having problems with to a new file named adapter-core.ts (should this go elsewhere or be named differently?) and resolved the issue there. Note that there were other adapters which had the same issue. I could apply this same fix there if this looks OK.