### PR TITLE
Add extendFuncMap to Predicate

### DIFF
--- a/src/predicate.ts
+++ b/src/predicate.ts
@@ -218,6 +218,12 @@ export class Predicate {
   //   }
   // };
 
+  static extendFuncMap (funcMap: {[key: string]: {fn: (...args: any[]) => any, dataType: DataType}}): void {
+    for (let func in (funcMap || {})) {
+      let config = funcMap[func];
+      FnExpr._funcMap[func] = config;
+    }
+  };
 
   /**
   'And's this Predicate with one or more other Predicates and returns a new 'composite' Predicate


### PR DESCRIPTION
Adding a function to extend the funcMap defined in FnExpr within the Predicate scope. This function is modeled after `extendBinaryPredicateFn`, This will allow adding functions that are available in OData 4, but that breeze does not have defined. 

For example, adding a `date` function to the funcMap:
```ts
Predicate.extendFuncMap({date: {fn: (date: Date) => new Date(date).setHours(0, 0, 0), dataType: DataType.DateTimeOffset }});
```
Afterwards, we can employ the OData 4 date function in the predicate:
```ts
let predicate = new breeze.Predicate("date(startDate)", "eq", dateValue);
```

The workaround for this would be to use a pass-thru predicate:
```ts
let predicate = new breeze.Predicate("date(startDate) eq " + dateValue);
```

Original PR Breeze/breeze.js#202