### PR TITLE
Non pk relations

### DIFF
--- a/src/entity-manager.ts
+++ b/src/entity-manager.ts
@@ -1128,7 +1128,7 @@ export class EntityManager {
       deletedKeys.forEach(key => {
         let entityType = em.metadataStore._getStructuralType(key.entityTypeName) as EntityType;
         let ekey = new EntityKey(entityType, key.keyValues);
-        let entity = em.findEntityByKey(ekey);
+        let entity = em.getEntityByKey(ekey);
         if (entity) {
           entity.entityAspect.setDetached();
         }
@@ -1588,7 +1588,7 @@ export class EntityManager {
           // check for empty keys - meaning that parent id's are not yet set.
           if (parentKey._isEmpty()) return;
           // if a child - look for parent in the em cache
-          let parent = em.findEntityByKey(parentKey);
+          let parent = em.getEntityByKey(parentKey);
           if (parent) {
             // if found hook it up
             entity.setProperty(np.name, parent);
@@ -1606,7 +1606,7 @@ export class EntityManager {
         // unidirectional fk props only
         let fkValue = entity.getProperty(fkProp.name);
         let parentKey = new EntityKey(invNp.parentType, [fkValue]);
-        let parent = em.findEntityByKey(parentKey);
+        let parent = em.getEntityByKey(parentKey);
 
         if (parent) {
           if (invNp.isScalar) {
@@ -1690,7 +1690,7 @@ function processServerErrors(saveContext: SaveContext, saveError: SaveErrorFromS
     if (serr.keyValues) {
       entityType = metadataStore._getStructuralType(serr.entityTypeName) as EntityType;
       let ekey = new EntityKey(entityType, serr.keyValues);
-      entity = entityManager.findEntityByKey(ekey);
+      entity = entityManager.getEntityByKey(ekey);
     }
 
     if (entityType && entity) {

--- a/src/entity-metadata.ts
+++ b/src/entity-metadata.ts
@@ -2299,7 +2299,9 @@ export class NavigationProperty {
   /** The server side names of the foreign key DataProperties associated with this NavigationProperty. There will usually only be a single DataProperty associated
   with a Navigation property except in the case of entities with multipart keys. __Read Only__ */
   foreignKeyNamesOnServer: string[];
+  /** The names of the foreign key DataProperties at the other end of the relationship. __Read Only__ */
   invForeignKeyNames: string[];
+  /** The server side names of the foreign key DataProperties at the other end of the relationship. __Read Only__ */
   invForeignKeyNamesOnServer: string[];
   /** The 'foreign key' DataProperties associated with this NavigationProperty. There will usually only be a single DataProperty associated
   with a Navigation property except in the case of entities with multipart keys. __Read Only__ */

--- a/src/mapping-context.ts
+++ b/src/mapping-context.ts
@@ -259,7 +259,7 @@ function mergeEntity(mc: MappingContext, node: any, meta: NodeMeta) {
   let isSaving = mc.query == null;
 
   let entityKey = entityType.getEntityKeyFromRawEntity(node, mc.rawValueFn);
-  let targetEntity = em.findEntityByKey(entityKey);
+  let targetEntity = em.getEntityByKey(entityKey);
   if (targetEntity) {
     if (isSaving && targetEntity.entityAspect.entityState.isDeleted()) {
       em.detachEntity(targetEntity);


### PR DESCRIPTION
Handle parent-child relations between entities where the child FK relates to a parent property that is not the parent's PK.

Tests for this are in the [breeze.js](https://github.com/Breeze/breeze.js/tree/master/test/internal) repo, in entityTests.js.

This pull request changes the `setDpValueSimple()` and `setNpValue()` functions of DefaultPropertyInterceptor, to update relations when setting properties, and the `_linkRelatedEntities()` function of EntityManager, to update relations when attaching entities.

This pull request also changes calls to `findEntityByKey()` to `getEntityByKey()` because the former is deprecated.