### PR TITLE
Update default-property-interceptor.ts

### DIFF
--- a/src/default-property-interceptor.ts
+++ b/src/default-property-interceptor.ts
@@ -12,6 +12,7 @@ export function defaultPropertyInterceptor(this: StructuralObject, property: Ent
 
   if (newValue === undefined) newValue = null; // remove? to allow assignment to undefined in Babel constructors?
   let oldValue = rawAccessorFn();
+  if (oldValue === undefined) oldValue = null; // remove? to allow assignment to undefined in Babel constructors?
 
   let dataType = (property as any).dataType;
   if (dataType && dataType.parse) {


### PR DESCRIPTION
Having issue with undefined navigation properties **undefined** on parent class. When the old value is also **undefined** it should just exit the function. But it is not because **newValue** _(null)_ === **oldValue** _(undefined)_ evaluate to **false**. Adding line 15 fixes the issue. But removing line 13 would also work.