### PR TITLE
Undefined should be null - oldValue in default-property-interceptor.ts

### DIFF
--- a/src/default-property-interceptor.ts
+++ b/src/default-property-interceptor.ts
@@ -12,6 +12,7 @@ export function defaultPropertyInterceptor(this: StructuralObject, property: Ent
 
   if (newValue === undefined) newValue = null; // remove? to allow assignment to undefined in Babel constructors?
   let oldValue = rawAccessorFn();
+  if (oldValue === undefined) oldValue = null; // remove? to allow assignment to undefined in Babel constructors?
 
   let dataType = (property as any).dataType;
   if (dataType && dataType.parse) {


### PR DESCRIPTION
I found a scenario where oldValue===newValue is evaluated to false (null===undefined evaluates to false) where it should not. This happen when the entity returned by the server has a null navigation properties for a property defined on an abstract parent class.